### PR TITLE
htm_index_reseller should be in files_reseller.conf

### DIFF
--- a/files_admin.conf
+++ b/files_admin.conf
@@ -1,5 +1,4 @@
 HTM_INDEX=admin/index.html
-HTM_INDEX_RESELLER=reseller/index.html
 HTM_INDEX_USER=user/index.html
 HTM_ACCOUNT_ADMIN_CREATE=admin/create_admin.html
 HTM_ACCOUNT_ADMIN_DELETE=admin/delete_admin.html

--- a/files_reseller.conf
+++ b/files_reseller.conf
@@ -1,4 +1,5 @@
 HTM_INDEX=reseller/index.html
+HTM_INDEX_RESELLER=reseller/index.html
 HTM_INDEX_USER=user/index.html
 HTM_RESELLER_TOP=reseller/template_reseller_top.html
 HTM_RESELLER_BOTTOM=reseller/template_reseller_bottom.html


### PR DESCRIPTION
Logged in as reseller, I could not access the reseller index.

Now for both admin and reseller users, the reseller index works.
