### PR TITLE
Change phpMyAdmin protocol to use |HTTP| variable

### DIFF
--- a/admin/menu_admin.html
+++ b/admin/menu_admin.html
@@ -87,7 +87,7 @@
 								<li><a href="/|HOME_MEMORY|"><span>Home</span></a></li>
 								<li><a href="/CMD_FILE_MANAGER"><span>File Manager</span></a></li>
 								<li><a href="http://|HELP_SECTION|"><span>Help</span></a></li>
-								<li><a href="http://|HOSTNAME|/pma"><span>PhpMyAdmin</span></a></li>
+								<li><a href="|HTTP|://|HOSTNAME|/pma"><span>PhpMyAdmin</span></a></li>
 								<li><a href="|WEBAPPS_SSL|://|HOSTNAME|/|WEBMAIL_LINK|"><span>Webmail</span></a></li>
 							</ul>
 						</div>

--- a/admin/menu_reseller.html
+++ b/admin/menu_reseller.html
@@ -87,7 +87,7 @@
 						<li><a href="/|HOME_MEMORY|"><span>Home</span></a></li>
 						<li><a href="/CMD_FILE_MANAGER"><span>File Manager</span></a></li>
 						<li><a href="http://|HELP_SECTION|"><span>Help</span></a></li>
-						<li><a href="http://|HOSTNAME|/pma"><span>PhpMyAdmin</span></a></li>
+						<li><a href="|HTTP|://|HOSTNAME|/pma"><span>PhpMyAdmin</span></a></li>
 						<li><a href="|WEBAPPS_SSL|://|HOSTNAME|/|WEBMAIL_LINK|"><span>Webmail</span></a></li>
 					</ul>
 				</div>

--- a/admin/menu_user.html
+++ b/admin/menu_user.html
@@ -88,7 +88,7 @@
 						<li><a href="/|HOME_MEMORY|"><span>Home</span></a></li>
 						<li><a href="/CMD_FILE_MANAGER"><span>File Manager</span></a></li>
 						<li><a href="http://|HELP_SECTION|"><span>Help</span></a></li>
-						<li><a href="http://|HOSTNAME|/pma"><span>PhpMyAdmin</span></a></li>
+						<li><a href="|HTTP|://|HOSTNAME|/pma"><span>PhpMyAdmin</span></a></li>
 						<li><a href="|WEBAPPS_SSL|://|HOSTNAME|/|WEBMAIL_LINK|"><span>Webmail</span></a></li>
 					</ul>
 				</div>

--- a/reseller/menu_reseller.html
+++ b/reseller/menu_reseller.html
@@ -84,7 +84,7 @@
 						<li><a href="/|HOME_MEMORY|"><span>Home</span></a></li>
 						<li><a href="/CMD_FILE_MANAGER"><span>File Manager</span></a></li>
 						<li><a href="http://|HELP_SECTION|"><span>Help</span></a></li>
-						<li><a href="http://|HOSTNAME|/pma"><span>PhpMyAdmin</span></a></li>
+						<li><a href="|HTTP|://|HOSTNAME|/pma"><span>PhpMyAdmin</span></a></li>
 						<li><a href="|WEBAPPS_SSL|://|HOSTNAME|/|WEBMAIL_LINK|"><span>Webmail</span></a></li>
 					</ul>
 				</div>

--- a/reseller/menu_user.html
+++ b/reseller/menu_user.html
@@ -84,7 +84,7 @@
 						<li><a href="/|HOME_MEMORY|"><span>Home</span></a></li>
 						<li><a href="/CMD_FILE_MANAGER"><span>File Manager</span></a></li>
 						<li><a href="http://|HELP_SECTION|"><span>Help</span></a></li>
-						<li><a href="http://|HOSTNAME|/pma"><span>PhpMyAdmin</span></a></li>
+						<li><a href="|HTTP|://|HOSTNAME|/pma"><span>PhpMyAdmin</span></a></li>
 						<li><a href="|WEBAPPS_SSL|://|HOSTNAME|/|WEBMAIL_LINK|"><span>Webmail</span></a></li>
 					</ul>
 				</div>

--- a/user/menu_user.html
+++ b/user/menu_user.html
@@ -74,7 +74,7 @@
             <li><a href="/|HOME_MEMORY|"><span>Home</span></a></li>
             <li><a href="/CMD_FILE_MANAGER"><span>File Manager</span></a></li>
             <li><a href="http://|HELP_SECTION|"><span>Help</span></a></li>
-            <li><a href="http://|HOSTNAME|/pma"><span>PhpMyAdmin</span></a></li>
+            <li><a href="|HTTP|://|HOSTNAME|/pma"><span>PhpMyAdmin</span></a></li>
             <li><a href="|WEBAPPS_SSL|://|HOSTNAME|/|WEBMAIL_LINK|"><span>Webmail</span></a></li>
           </ul>
         </div>


### PR DESCRIPTION
The |HTTP| variable is used in the default templates, because if SSL is available, it should be preferred over plain text.

As per comment here: http://www.directadmin.com/features.php?id=1502
Links to phpMyAdmin are already set to use |HTTP| which is controlled by SSL=1|0 in the directadmin.conf...
